### PR TITLE
eep-18: Fix link to json-and-json-rpc blog post

### DIFF
--- a/eeps/eep-0018.md
+++ b/eeps/eep-0018.md
@@ -981,7 +981,7 @@ None.
     "CouchDB"
 [6b]: http://wiki.apache.org/couchdb/
     "CouchDB"
-[7]: www.lshift.net/blog/2007/02/17/json-and-json-rpc-for-erlang
+[7]: https://leastfixedpoint.com/tonyg/kcbbs/lshift_archive/json-and-json-rpc-for-erlang-20070217.html
     "rfc4627 module for Erlang from LShift"
 [8]: http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-262.pdf
     "ECMA standard 262, ECMAScript"


### PR DESCRIPTION
The link was written incorrectly (no http:// prefix) and pointed
to a moved website. Now the link is correct and points to the
correct place.